### PR TITLE
Catch HTTP status error and JSON response error

### DIFF
--- a/uEagle/uEagle.py
+++ b/uEagle/uEagle.py
@@ -60,9 +60,17 @@ class Eagle(object):
         response = requests.post(self.addr,
                                  headers=self._headers,
                                  data=post_data)
+        
+        if(response.status_code != 200):
+            response.raise_for_status()
 
         response_text = TEMP_RESPONSE_FIX(response.text)
-        data = json.loads(response_text)
+
+        try:
+            data = json.loads(response_text)
+        except ValueError as error:
+            raise ValueError("Invalid JSON format: %s", error)
+
         process_data(data)
         return data
 


### PR DESCRIPTION
I'm hoping this Fixes #6 

Along with this code change I'll modify the `hwtest()` method in the Home Assistant `rainforest_eagle` `sensor.py` code:
<img width="489" alt="Screen Shot 2020-12-01 at 10 42 29 PM" src="https://user-images.githubusercontent.com/34967045/100838005-87ff7700-3426-11eb-9dc6-baf1637f28fd.png">
https://github.com/gtdiehl/core/blob/179de169c74f8d47efbf324a8b79cd9ce1237304/homeassistant/components/rainforest_eagle/sensor.py#L55-L60